### PR TITLE
Change the set-output command with the environment file GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,8 @@ done < "$input"
 echo "<<<<<< Output of errors file end"
 # Present the full application log output 
 echo ">>>>>> Output of full application log start"
-echo "::set-output name=results::$output"
+#echo "::set-output name=results::$output"  DEPRECATED
+echo "results=$output" >> GITHUB_OUTPUT
 echo "<<<<<< Output of full application log end"
 
 # Fail the action if errors are detected


### PR DESCRIPTION
This is explained in: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
